### PR TITLE
Explicity set contextIsolation for Electron 12

### DIFF
--- a/lib/worker-manager.js
+++ b/lib/worker-manager.js
@@ -267,8 +267,17 @@ export class RendererProcess {
     this.onStdinError = onStdinError;
     this.onExecStarted = onExecStarted;
 
-    this.win = new BrowserWindow({show: !!process.env.ATOM_GITHUB_SHOW_RENDERER_WINDOW,
-      webPreferences: {nodeIntegration: true, enableRemoteModule: true}});
+    this.win = new BrowserWindow({
+      show: !!process.env.ATOM_GITHUB_SHOW_RENDERER_WINDOW,
+      webPreferences: {
+        nodeIntegration: true,
+        enableRemoteModule: true,
+
+        // The default of contextIsolation is changed to true so we'll have to set it to false.
+        // See https://github.com/electron/electron/issues/23506 for more information
+        contextIsolation: false
+      },
+    });
     this.webContents = this.win.webContents;
     // this.webContents.openDevTools();
 


### PR DESCRIPTION
### Description of the Change

Since Electron 12, the default of `contextIsolation` is changed to `true` from `false` so we'll have to set it to false explicitly. Otherwise, Node APIs won't be used in renderer processes. Example of error in the console:
```
[84267:1009/105137.986708:INFO:CONSOLE(7)] "Uncaught ReferenceError: require is not defined", source: file:///Users/bongnguyen/projects/pulsar/node_modules/github/lib/renderer.html?js=%2FUsers%2Fbongnguyen%2Fprojects%2Fpulsar%2Fnode_modules%2Fgithub%2Flib%2Fworker.js&managerWebContentsId=1&operationCountLimit=10&channelName=github%3Arenderer-ipc (7)
[84267:1009/105137.986816:INFO:CONSOLE(15)] "Uncaught ReferenceError: process is not defined", source: file:///Users/bongnguyen/projects/pulsar/node_modules/github/lib/renderer.html?js=%2FUsers%2Fbongnguyen%2Fprojects%2Fpulsar%2Fnode_modules%2Fgithub%2Flib%2Fworker.js&managerWebContentsId=1&operationCountLimit=10&channelName=github%3Arenderer-ipc (15)
[84267:1009/105137.996283:INFO:CONSOLE(7)] "Uncaught ReferenceError: require is not defined", source: file:///Users/bongnguyen/projects/pulsar/node_modules/github/lib/renderer.html?js=%2FUsers%2Fbongnguyen%2Fprojects%2Fpulsar%2Fnode_modules%2Fgithub%2Flib%2Fworker.js&managerWebContentsId=2&operationCountLimit=10&channelName=github%3Arenderer-ipc (7)
[84267:1009/105137.996381:INFO:CONSOLE(15)] "Uncaught ReferenceError: process is not defined", source: 
```

See https://github.com/electron/electron/issues/23506 for more information.

### Screenshot or Gif

N/A

### Applicable Issues

N/A
