### PR TITLE
meta: Revert "main" to "./lib/index", no dist (fix package on `master` branch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "main": "./dist/index",
+  "main": "./lib/index",
   "version": "0.36.13",
   "description": "GitHub integration",
   "repository": "https://github.com/pulsar-edit/github",


### PR DESCRIPTION
We don't have the `dist/` dir on `master` branch.

If package.json "main" field points to this non-existent folder, then the package is effectively broken.

This commit restores "main" to point to "./lib/index", as this seems to be working now in my tests.

We can pre-compile the `dist/` folder again when tagging the next release, if we really want to, but I'm pretty sure Pulsar compiles the code on first run, so the stakes for doing so seem pretty small to me. (Impact should be limited to improvements in first startup speed, if I understand correctly.)

\[ EDIT: Transpilation on-demand only works when the package is installed to `~/.pulsar/packages/`. It does **not** get auto-transpiled if it's a bundled/core package. Ah, well. We still have to transpile, I guess. \]

---

Note: according to Mauricio, the command to build the `dist/` dir is: `ELECTRON_VERSION=12 babel lib -d dist --compact auto --source-type module`

But it is not trivially obvious to me how to automate this at the moment, so I won't try to do so for now. This just gets the repo working on `master` branch again, without bothering with pre-compilation stuff.

\[ EDIT TO ADD, NOTE: This section below the divider line was documenting a previously undocumented build step, but was ultimately off-topic in terms of actionable items for this PR. Was strictly advisory, wanted to write it down so I did not forget how to do the step!!! This section was not actually germane to how to evaluate this PR on its own merits, IMO!!!!! Arguably I should not have mentioned it, since it is off-topic!!! Please don't let this bit distract you, reviewers! Thank you! \]