### PR TITLE
lib: Rebrand getAtomAppName() function (fix shelling out to `git` on macOS)

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -93,7 +93,7 @@ function getAtomAppName() {
   return 'Pulsar Helper';
   */
 
-  return `${atom?.branding?.name || 'Pulsar'} Helper`;
+  return `${atom?.branding?.name ?? 'Pulsar'} Helper`;
 }
 
 export function getAtomHelperPath() {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -82,13 +82,18 @@ export function getPackageRoot() {
 }
 
 function getAtomAppName() {
+  /*
+  // Old Atom logic (restore this if we make release channel specific binaries)
   const match = atom.getVersion().match(/-([A-Za-z]+)(\d+|-)/);
   if (match) {
     const channel = match[1];
-    return `Atom ${channel.charAt(0).toUpperCase() + channel.slice(1)} Helper`;
+    return `Pulsar ${channel.charAt(0).toUpperCase() + channel.slice(1)} Helper`;
   }
 
-  return 'Atom Helper';
+  return 'Pulsar Helper';
+  */
+
+  return `${atom?.branding?.name || 'Pulsar'} Helper`;
 }
 
 export function getAtomHelperPath() {


### PR DESCRIPTION
\[ EDIT: _this PR applies to macOS only_ \]

Fixes pushing to a git remote, and probably fixes shelling out to the system's `git` command in general.

Note: I used the `branding` API, so if anyone forks Pulsar, this bit should hopefully still work for them. But if the `branding` API doesn't work/isn't available for whatever reason, this falls back to just return `Pulsar Helper.app` (hard-coded). It was simple enough to do it this way, so I figured, "why not?"