### PR TITLE
lib: Update login instructions for PATs, not OAuth

### DIFF
--- a/lib/views/github-login-view.js
+++ b/lib/views/github-login-view.js
@@ -63,8 +63,12 @@ export default class GithubLoginView extends React.Component {
         <div className="github-GitHub-LargeIcon icon icon-mark-github" />
         <h1>Enter Token</h1>
         <ol>
-          <li>Visit <a href="https://github.atom.io/login">github.atom.io/login</a> to generate
+          <li>Visit <a href="https://github.com/settings/tokens">github.com/settings/tokens</a> to generate
           an authentication token.</li>
+          <ul>
+            <li>Generate a new token (classic) with at least the following permissions:
+            <code>repo</code>, <code>workflow</code>, <code>read:org</code>, and <code>user:email</code>.</li>
+          </ul>
           <li>Enter the token below:</li>
         </ol>
 

--- a/lib/views/github-login-view.js
+++ b/lib/views/github-login-view.js
@@ -63,12 +63,13 @@ export default class GithubLoginView extends React.Component {
         <div className="github-GitHub-LargeIcon icon icon-mark-github" />
         <h1>Enter Token</h1>
         <ol>
-          <li>Visit <a href="https://github.com/settings/tokens">github.com/settings/tokens</a> to generate
-          an authentication token.</li>
-          <ul>
-            <li>Generate a new token (classic) with at least the following permissions:
-            <code>repo</code>, <code>workflow</code>, <code>read:org</code>, and <code>user:email</code>.</li>
-          </ul>
+          <li>
+            Visit <a href="https://github.com/settings/tokens">github.com/settings/tokens</a> to generate a new
+            Personal Access Token (classic).<sup><a href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic">[docs]</a></sup>
+          </li>
+          <li>
+            Ensure it has the following permissions: <code>repo</code>, <code>workflow</code>, <code>read:org</code>, and <code>user:email</code>.
+          </li>
           <li>Enter the token below:</li>
         </ol>
 


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

<details><Summary><b>Requirements</b> (from template, click to expand):</summary>

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

</details>

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Update login instructions to direct users to generate a Personal Access Token via github.com/settings/tokens, instead of via the unavailable github.atom.io/login (OAuth token generator) page.

Also: Add written directions about which scopes are needed, as users will now have to manually select the scopes they need on their own tokens in order for the github package to function right (and not reject the token for having insufficient permissions/scopes).

(The OAuth flow via github.atom.io/login *used to* specify the scopes without user input or control, other than the choice to grant or not grant access. Now we must advise users of which scopes are needed.)

### Screenshot or Gif

<!-- If the changes are visual, add a screenshot or record a Gif. This doesn't have to be updated during implementation, but after a PR is merged, a final screenshot/gif should be added. It might get used for blog posts, documentation etc. Write "N/A" if not applicable. -->

<details><summary>Before (click to expand):</summary>

![GitHub package tab showing instructions for the github atom io slash login login flow](https://user-images.githubusercontent.com/20157115/219981618-c185fe61-5fb2-4bc8-86e5-ef0605b368bb.png)

</details>

<details><summary>After (click to expand):</summary>

![GitHub package tab showing instructions for the github com slash settings slash tokens login flow](https://user-images.githubusercontent.com/20157115/219981616-a342d59f-a1ca-4eb2-8145-2f41b9e5fe1e.png)

</details>

### Applicable Issues

<!-- Cross-reference any applicable Issues here. Use "Fixes #NNN" or "Closes #NNN" syntax to automatically close linked issues on merge. -->

Fixes #7

See also: (essentially fixes): https://github.com/atom/github/issues/2686

**NOTE:** I included the [`workflow` scope](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes) in these new instructions. The old github.atomio/login OAuth token did not have this scope. The `workflow` scope was separated out from the general `repo` scope after maintenance of the official Atom github package had already diminished, so it was never fixed there. Setting the `workflow` scope on a PAT and using that instead of the OAuth token was the very same best workaround as was available for some years, so I rolled that into this PR. (See again issue https://github.com/atom/github/issues/2686).

`workflow` scope is not needed unless you need to push updated GitHub Actions YAML files up to your remote, however.

So these instructions go beyond bare minimum permissions/scopes needed to get up and running and do things :tm: with the github package, but it's just really confusing when [only] pushes that touch your GitHub Actions workflow YML files fail, potentially with a confusing or inaccurate error message as to why. And explaining it is harder than telling folks to set the permission.

So rather than delve into these fine details that are hard to explain and which people may not wish to think hard about when they don't have to... I just instructed folks to set the `workflow` scope whether they need to or not.

Much like the package could easily be changed to only require `public_repo` scope for repo access instead of the catch-all `repo` scope.

### TO-DOs

Maybe explain when/why the `workflow` scope is needed in these instructions. (I dunno, man.)

Maybe update the app to require `public_repo` rather than full-on `repo` in terms of repo access scopes, and explain when/why you need full-on `repo` (for private repo access, basically).

**NOTE:** I consider both of these OUT OF SCOPE for the current PR. I respectfully ask that reviewers not ask that these be added to this PR, in order to avoid "scope creep" (pun not intended, but I'll take it) of this PR, review complexity, haggling over finer details, please and thank you. This is the targeted fix aimed at enabling folks to get authed in the github package without knowing ahead of time these precise instructions, or having to find them on the Discord somewhere, etc. etc.