### PR TITLE
switch defaultBranchName to `main` on new repo

### DIFF
--- a/lib/views/create-dialog.js
+++ b/lib/views/create-dialog.js
@@ -46,7 +46,7 @@ export async function publishRepository(
   if (repository.isEmpty()) {
     wasEmpty = true;
     await repository.init();
-    defaultBranchName = 'master';
+    defaultBranchName = 'main';
   } else {
     wasEmpty = false;
     const branchSet = await repository.getBranches();


### PR DESCRIPTION
thanks for this project to maintain atom

This PR makes the default branch name `main` when adding a new repo . 
Ideally this would be configurable in the settings, but this is a stopgap. 
https://github.com/atom/github/pull/2794