### PR TITLE
Add logout menu option

### DIFF
--- a/menus/git.cson
+++ b/menus/git.cson
@@ -34,6 +34,10 @@
             'label': 'Open Reviews Tab'
             'command': 'github:open-reviews-tab'
           }
+          {
+            'label': 'Log Out'
+            'command': 'github:logout'
+          } 
         ]
       }
     ]


### PR DESCRIPTION
Adds a logout menu item to `Packages > GitHub`.
Stems from a conversation on Discord where three of us couldn't work out how to log out once the token was entered other than manually deleting it from the keyring. This isn't a perfect solution (we could probably add a button to the main panel or something) but at least it isn't hidden purely behind a command and can be found by looking where people might reasonably look for such an option.