### PR TITLE
lib: Allow parent scopes when checking if each required scope is set

### DIFF
--- a/lib/models/github-login-model.js
+++ b/lib/models/github-login-model.js
@@ -72,10 +72,14 @@ export default class GithubLoginModel {
             if (!scopeSet.has(scope)) {
               if (scope === 'read:org' && scopeSet.has('admin:org')) {
                 // 'admin:org' is a superset of, and implies, 'read:org'.
+                console.warn('Excessive scopes detected on your github token. Please only set the actually needed scopes on your PAT.')
+                console.warn('Excessive scope "admin:org" should be "read:org" instead.')
                 continue;
               }
               if (scope === 'user:email' && scopeSet.has('user')) {
                 // 'user' is a superset of, and implies, 'user:email'.
+                console.warn('Excessive scopes detected on your github token. Please only set the actually needed scopes on your PAT.')
+                console.warn('Excessive scope "user" should be "user:email" instead.')
                 continue;
               }
               // Token doesn't have enough OAuth scopes, need to reauthenticate

--- a/lib/models/github-login-model.js
+++ b/lib/models/github-login-model.js
@@ -70,6 +70,14 @@ export default class GithubLoginModel {
 
           for (const scope of this.constructor.REQUIRED_SCOPES) {
             if (!scopeSet.has(scope)) {
+              if (scope === 'read:org' && scopeSet.has('admin:org')) {
+                // 'admin:org' is a superset of, and implies, 'read:org'.
+                continue;
+              }
+              if (scope === 'user:email' && scopeSet.has('user')) {
+                // 'user' is a superset of, and implies, 'user:email'.
+                continue;
+              }
               // Token doesn't have enough OAuth scopes, need to reauthenticate
               this.checked.set(fingerprint, INSUFFICIENT);
               return INSUFFICIENT;

--- a/lib/models/github-login-model.js
+++ b/lib/models/github-login-model.js
@@ -88,6 +88,7 @@ export default class GithubLoginModel {
                 continue;
               }
               // Token doesn't have enough OAuth scopes, need to reauthenticate
+              console.log("GitHub token doesn't have a required scope! Missing: " + scope);
               this.checked.set(fingerprint, INSUFFICIENT);
               return INSUFFICIENT;
             }

--- a/lib/models/github-login-model.js
+++ b/lib/models/github-login-model.js
@@ -8,7 +8,7 @@ let instance = null;
 export default class GithubLoginModel {
   // Be sure that we're requesting at least this many scopes on the token we grant through github.atom.io or we'll
   // give everyone a really frustrating experience ;-)
-  static REQUIRED_SCOPES = ['repo', 'read:org', 'user:email']
+  static REQUIRED_SCOPES = ['public_repo', 'read:org', 'user:email']
 
   static get() {
     if (!instance) {
@@ -70,6 +70,11 @@ export default class GithubLoginModel {
 
           for (const scope of this.constructor.REQUIRED_SCOPES) {
             if (!scopeSet.has(scope)) {
+              if (scope === 'public_repo' && scopeSet.has('repo')) {
+                // 'repo' is a superset of, and implies, 'public_repo'.
+                // Setting just 'public_repo' or full 'repo' both have legitimate use-cases. So we won't warn about it.
+                continue;
+              }
               if (scope === 'read:org' && scopeSet.has('admin:org')) {
                 // 'admin:org' is a superset of, and implies, 'read:org'.
                 console.warn('Excessive scopes detected on your github token. Please only set the actually needed scopes on your PAT.')

--- a/lib/views/github-login-view.js
+++ b/lib/views/github-login-view.js
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {autobind} from '../helpers';
+import {INSUFFICIENT} from '../shared/keytar-strategy';
 
 export default class GithubLoginView extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     onLogin: PropTypes.func,
+    tokenStatus: PropTypes.symbol,
   }
 
   static defaultProps = {
@@ -15,6 +17,7 @@ export default class GithubLoginView extends React.Component {
     <span>Log in to GitHub to access PR information and more!</span>
   </div>,
     onLogin: token => {},
+    tokenStatus: Symbol(),
   }
 
   constructor(props, context) {
@@ -57,7 +60,15 @@ export default class GithubLoginView extends React.Component {
     );
   }
 
+  renderTokenHint() {
+    if (this.props.tokenStatus === INSUFFICIENT) {
+      return(<span>Hint: Entered token has insufficient scopes. Update the scopes on your token and try again. See Dev Tools console for details.</span>);
+    }
+  }
+
   renderTokenInput() {
+    const tokenHint = this.renderTokenHint();
+
     return (
       <form className="github-GithubLoginView-Subview" onSubmit={this.handleSubmitToken}>
         <div className="github-GitHub-LargeIcon icon icon-mark-github" />
@@ -72,6 +83,8 @@ export default class GithubLoginView extends React.Component {
           </li>
           <li>Enter the token below:</li>
         </ol>
+
+        {tokenHint}
 
         <input
           type="text"

--- a/lib/views/github-login-view.js
+++ b/lib/views/github-login-view.js
@@ -75,8 +75,10 @@ export default class GithubLoginView extends React.Component {
         <h1>Enter Token</h1>
         <ol>
           <li>
-            Visit <a href="https://github.com/settings/tokens">github.com/settings/tokens</a> to generate a new
-            Personal Access Token (classic).<sup><a href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic">[docs]</a></sup>
+            Visit <a href="https://github.com/settings/tokens/new?scopes=repo,workflow,user:email,read:org&description=Pulsar%20github%20package">
+              github.com/settings/tokens
+            </a> to generate a new Personal Access Token (classic).
+            <sup><a href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic">[docs]</a></sup>
           </li>
           <li>
             Ensure it has the following permissions: <code>repo</code>, <code>workflow</code>, <code>read:org</code>, and <code>user:email</code>.

--- a/lib/views/github-tab-view.js
+++ b/lib/views/github-tab-view.js
@@ -81,7 +81,7 @@ export default class GitHubTabView extends React.Component {
 
     if (this.props.token === INSUFFICIENT) {
       return (
-        <GithubLoginView onLogin={this.props.handleLogin}>
+        <GithubLoginView onLogin={this.props.handleLogin} tokenStatus={INSUFFICIENT}>
           <p>
             Your token no longer has sufficient authorizations. Please re-authenticate and generate a new one.
           </p>


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

- When checking for required scopes (were `repo`, `user:email` and `read:org` before this PR), allow parent scopes "instead".
  - (`repo` is already top-level)
  - (`user` is the parent scope of, and implies, `user:email`. Accept `user` "instead of" `user:email` if `user:email` isn't narrowly/explicitly found on the token.)
  - (`admin:org` is the parent scope of, and implies `read:org`. Accept `admin:org` if `read:org` not explicitly/specifically seen on the token.)
  - Warn in the console which exact scope was missing. (See below why I didn't put that in the UI.)
- Show a hint in the UI when a token with insufficient scopes has been entered.
- Warn in the console if parent scopes of our actually required scopes are put on the token, since that's excessive permissions, and we won't even use those extra permissions. (Bad security posture for our users to do this.) (Kind of unlikely anyone will ever see this, but oh well... Harder to investigate and implement the right way to do this in the UI.)
- Allow just `public_repo` scope instead of full-on `repo` (but accept `repo` as its parent scope).
- Pre-populate the recommended scopes in the "new Personal Access Token" link in the token entry view

### Screenshot or Gif

<!-- If the changes are visual, add a screenshot or record a Gif. This doesn't have to be updated during implementation, but after a PR is merged, a final screenshot/gif should be added. It might get used for blog posts, documentation etc. Write "N/A" if not applicable. -->

<details><summary><b>Hint in token entry view when token is missing required scope(s)</b> (click to expand):</summary>

![Token entry view in the github package for Pulsar, showing a hint "Hint: Entered token has insufficient scopes. Update the scopes on your token and try again. See Dev Tools console for details."](https://github.com/pulsar-edit/github/assets/20157115/a46c0840-5715-4bc1-a321-330ce9e51d0e)

</details>

<details><summary><b>Message in Developer Tools console when missing a required scope</b> (click to expand):</summary>

![Message in Developer Tools console "GitHub token doesn't have a required scope! Missing: public_repo"](https://github.com/pulsar-edit/github/assets/20157115/4ca18831-f44b-4768-93f2-b9db61a053d4)

</details>

<details><summary><b>Warning in Developer Tools console when excessive scopes are set on the token</b> (click to expand):</summary>

![Warning about excessive scopes in Developer Tools console](https://github.com/pulsar-edit/github/assets/20157115/819ecd53-afbd-4f64-8ae7-ac67109f215b)

</details>

### Applicable Issues

<!-- Cross-reference any applicable Issues here. Use "Fixes #NNN" or "Closes #NNN" syntax to automatically close linked issues on merge. -->

Mostly fixes https://github.com/pulsar-edit/pulsar/issues/801.

### Alternative Approaches

NOTE: I did not update the recommended scopes, since I haven't thoroughly tested what might subtly break if not having full `repo` scope, and this allows just setting `public_repo`, `read:org` and `user:email`. I don't have time to test what a sensible minimum is, and for folks who use private repos, I don't want to have to have a page long explanation of all the intricacies of the different scopes and what they do, especially since the token entry view does not have a scroll bar at the moment!!! Too long of a blurb puts the actual token entry box off of the screen on certain display sizes!!!!!!!!!!!!!!!! (!!!)

The warning info in the UI could show the specific missing scope, but that would have to be plumbed into the UI message. That would involve more work to send the info along from the login model and the call site, where we can know what the missing scope is, to the called view, which currently doesn't know that info... It needs to know that info at its render time, in order to renderer the specific scope into the UI.

We could also warn in the UI if a totally invalid token (typo'd, or expired/deleted) is entered, but most of the existing code assumes "maybe it was just a network error" as the same status as "definitely an invalid token" --> either is just "_maybe_ an invalid token". The package doesn't try to distinguish/leaves the situation there, and it acts like you haven't entered anything at all. So, this would take more work than simply plugging in existing bit A to existing bit B, we would have to teach some part of the code to recognize a non-empty token that is wrong even after there was no network error during checking the scopes over the network (it's an API request to the GitHub REST API server). i.e. we need to define a state for when we got a response back from GitHub that the token is actually genuinely (confirmed) invalid.

I kept it relatively simple for this PR. The above is definitely doable, I just wasn't sure if it would be worth it and kind of ran out of steam to do it right here/right now, to be honest.

### Misc Notes about scopes

- Just `public_repo` is all that seems to be needed from my testing, unless you're working with private repositories.
- I suppose `read:org` is needed for working with org-owned repos, but I didn't test this to confirm?
- Not sure what the reason for why `user:email` is needed is, TBH, but too afraid to ask (ain't got time to look this up right now, to be honest.