### PR TITLE
Auto 'pretranspile' package on release creation

### DIFF
--- a/.github/stripAtomTranspilers.js
+++ b/.github/stripAtomTranspilers.js
@@ -2,7 +2,7 @@
   This small script strips the `atomTranspilers` key from the repos `package.json`.
   Which prevents the editor (Pulsar) from trying to transpile the package at
   startup time, which is unnecessary and redudant on a 'pretranspiled' tag of the
-  package. Should save some CPU cycles.
+  package. Should save some CPU cycles... and prevent errors if `devDependencies` aren't present.
 */
 
 const fs = require("node:fs");

--- a/.github/stripAtomTranspilers.js
+++ b/.github/stripAtomTranspilers.js
@@ -1,0 +1,14 @@
+/**
+  This small script strips the `atomTranspilers` key from the repos `package.json`.
+  Which prevents the editor (Pulsar) from trying to transpile the package at
+  startup time, which is unnecessary and redudant on a 'pretranspiled' tag of the
+  package. Should save some CPU cycles.
+*/
+
+const fs = require("node:fs");
+
+const pkgJSON = JSON.parse(fs.readFileSync("./package.json", { encoding: "utf8" }));
+
+delete pkgJSON.atomTranspilers;
+
+fs.writeFileSync("./package.json", JSON.stringify(pkgJSON, null, 2) + '\n', { encoding: "utf8" });

--- a/.github/workflows/transpile.yml
+++ b/.github/workflows/transpile.yml
@@ -1,9 +1,21 @@
 name: Auto-Transpile
 
 on:
-  release:
-    types: [created]
   workflow_dispatch:
+    inputs:
+      releaseType:
+        description: "The semver bump type for this release."
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+          - premajor
+          - preminor
+          - prepatch
+          - prerelease
 
 env:
   ELECTRON_VERSION: 30.5.1
@@ -34,10 +46,22 @@ jobs:
           git --version
           git config --global user.name "Pulsar-Edit Bot"
           git config --global user.email "<no-reply@users-github.com>"
+      - name: Disable NPM Git tag creation on version bump
+        run: npm config set git-tag-version false
+      - name: Bump Version
+        run: npm version ${{ inputs.releaseType }}
+      - name: Commit changes
+        run: |
+          git add
+          git commit -m "Bump Version"
       - name: Find Current Version
         run: |
           NODE_PKG_VERSION=$(node -p "require('./package.json').version")
           echo "NODE_PKG_VERSION=$NODE_PKG_VERSION" >> $GITHUB_ENV
+      - name: Tag changes as base tag
+        run: git tag v${{ env.NODE_PKG_VERSION }}
+      - name: Push base tag to remote
+        run: git push oriign v${{ env.NODE_PKG_VERSION }}
       - name: Create new pretranspiled branch
         run: git switch -c v${{ env.NODE_PKG_VERSION }}-pretranspiled-working-branch
       - name: Transpile Source

--- a/.github/workflows/transpile.yml
+++ b/.github/workflows/transpile.yml
@@ -5,6 +5,9 @@ on:
     types: [created]
   workflow_dispatch:
 
+env:
+  ELECTRON_VERSION: 30.5.1
+
 jobs:
   transpile:
     runs-on: ubuntu-latest
@@ -38,7 +41,7 @@ jobs:
       - name: Create new pretranspiled branch
         run: git switch -c v${{ env.NODE_PKG_VERSION }}-pretranspiled
       - name: Transpile Source
-        run: ELECTRON_VERSION=30.5.1 babel lib -d lib --compact auto --source-type module
+        run: ELECTRON_VERSION=${{ env.ELECTRON_VERSION }} babel lib -d lib --compact auto --source-type module
       - name: Strip `atomTranspilers` from `package.json`
         run: node ./.github/stripAtomTranspilers.js
       - name: Commit changes

--- a/.github/workflows/transpile.yml
+++ b/.github/workflows/transpile.yml
@@ -60,8 +60,10 @@ jobs:
           echo "NODE_PKG_VERSION=$NODE_PKG_VERSION" >> $GITHUB_ENV
       - name: Tag changes as base tag
         run: git tag v${{ env.NODE_PKG_VERSION }}
+      - name: Push updated default branch to remote
+        run: git push
       - name: Push base tag to remote
-        run: git push oriign v${{ env.NODE_PKG_VERSION }}
+        run: git push origin v${{ env.NODE_PKG_VERSION }}
       - name: Create new pretranspiled branch
         run: git switch -c v${{ env.NODE_PKG_VERSION }}-pretranspiled-working-branch
       - name: Transpile Source

--- a/.github/workflows/transpile.yml
+++ b/.github/workflows/transpile.yml
@@ -50,14 +50,14 @@ jobs:
         run: npm config set git-tag-version false
       - name: Bump Version
         run: npm version ${{ inputs.releaseType }}
-      - name: Commit changes
-        run: |
-          git add
-          git commit -m "Bump Version"
       - name: Find Current Version
         run: |
           NODE_PKG_VERSION=$(node -p "require('./package.json').version")
           echo "NODE_PKG_VERSION=$NODE_PKG_VERSION" >> $GITHUB_ENV
+      - name: Commit changes
+        run: |
+          git add
+          git commit -m "Bump Version to v${{ env.NODE_PKG_VERSION }}"
       - name: Tag changes as base tag
         run: git tag v${{ env.NODE_PKG_VERSION }}
       - name: Push updated default branch to remote

--- a/.github/workflows/transpile.yml
+++ b/.github/workflows/transpile.yml
@@ -39,7 +39,7 @@ jobs:
           NODE_PKG_VERSION=$(node -p "require('./package.json').version")
           echo "NODE_PKG_VERSION=$NODE_PKG_VERSION" >> $GITHUB_ENV
       - name: Create new pretranspiled branch
-        run: git switch -c v${{ env.NODE_PKG_VERSION }}-pretranspiled
+        run: git switch -c v${{ env.NODE_PKG_VERSION }}-pretranspiled-working-branch
       - name: Transpile Source
         run: ELECTRON_VERSION=${{ env.ELECTRON_VERSION }} babel lib -d lib --compact auto --source-type module
       - name: Strip `atomTranspilers` from `package.json`
@@ -50,7 +50,5 @@ jobs:
           git commit -m "Pretranspile package"
       - name: Tag changes
         run: git tag v${{ env.NODE_PKG_VERSION }}-pretranspiled
-      - name: Push branch to remote
-        run: git push -u origin v${{ env.NODE_PKG_VERSION }}-pretranspiled
       - name: Push tag to remote
         run: git push origin v${{ env.NODE_PKG_VERSION }}-pretranspiled

--- a/.github/workflows/transpile.yml
+++ b/.github/workflows/transpile.yml
@@ -1,0 +1,53 @@
+name: Auto-Transpile
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  transpile:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v5
+      - name: Setup NodeJS
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ vars.NODE_VERSION }} # Use org defined NODE_VERSION
+      - name: Install Dependencies
+        run: npm install --legacy-peer-deps
+        # The legacy-peer-deps flag matches how `pulsar -p install` behaves
+      - name: Install NPM Tooling
+        run: npm install -g @babel/cli @babel/core
+      - name: Log Globally installed NPM tooling
+        run: npm ls -g
+      - name: Log babel version
+        run: npx babel --version
+      - name: Setup Git User
+        run: |
+          git --version
+          git config --global user.name "Pulsar-Edit Bot"
+          git config --global user.email "<no-reply@users-github.com>"
+      - name: Find Current Version
+        run: |
+          NODE_PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "NODE_PKG_VERSION=$NODE_PKG_VERSION" >> $GITHUB_ENV
+      - name: Create new pretranspiled branch
+        run: git switch -c v${{ env.NODE_PKG_VERSION }}-pretranspiled
+      - name: Transpile Source
+        run: ELECTRON_VERSION=30.5.1 babel lib -d lib --compact auto --source-type module
+      - name: Strip `atomTranspilers` from `package.json`
+        run: node ./.github/stripAtomTranspilers.js
+      - name: Commit changes
+        run: |
+          git add
+          git commit -m "Pretranspile package"
+      - name: Tag changes
+        run: git tag v${{ env.NODE_PKG_VERSION }}-pretranspiled
+      - name: Push branch to remote
+        run: git push -u origin v${{ env.NODE_PKG_VERSION }}-pretranspiled
+      - name: Push tag to remote
+        run: git push origin v${{ env.NODE_PKG_VERSION }}-pretranspiled


### PR DESCRIPTION
Previously, to pretranspile a package it was a combination of dark arts and arcane magic thought up by the deranged, that was decoded by @mauricioszabo and later transcribed by @DeeDeeG.

Reference:
- https://github.com/pulsar-edit/github/commit/ebd8c6bee823ebd1bafe3d3c97221c397a1ae687
- https://github.com/pulsar-edit/github/commit/7bb1987af7dbff127d25855b52307232669206c6

This PR aims to codify and automate it.

This PR adds a GHA workflow that on a release creation will automatically create a tag of the same version appended with `-pretranspile`, to match our current conventions.

Keeping with best practices of using our org defined NodeJS version that'll match Pulsar's current version, and unfortunately a hardcoded Electron version that we will have to keep updated with Pulsar, as well as lots of inspiration taken from our `pulsar-release-workflow`, `pulsar-chocolatey`, and `action-pulsar-dependency`, we should have something that "Just Works ™" here.

Only real way to test it is to run it, so with the upcoming PR from @DeeDeeG to bump some dependencies to resolve issues I'm facing in [`pulsar-edit/pulsar#1508`](https://github.com/pulsar-edit/pulsar/pull/1508), it'll be the perfect time to test.